### PR TITLE
Add Endpoint Option for Local Development

### DIFF
--- a/lib/adapter/queue-adapter.js
+++ b/lib/adapter/queue-adapter.js
@@ -19,15 +19,30 @@ module.exports = exports = class QueueAdapter {
    */
   constructor(options = {}) {
     let credentials = null
+    let endpoint = null
+    options.region = options.region || 'us-east-1'
 
     if (options.awsAccessKey && options.awsSecretKey) {
       credentials = { accessKeyId: options.awsAccessKey, secretAccessKey: options.awsSecretKey }
     }
 
-    this.#sqsClient = options.sqsClient || new SQSClient({ region: options.region || 'us-east-1', credentials })
+    if (options.endpoint) {
+      endpoint = options.endpoint
+    }
+
+    this.#sqsClient = options.sqsClient || new SQSClient({ region: options.region, credentials, endpoint })
   }
 
   #sqsClient
+
+  /**
+   * Get the SQS client instance. Used mainly for unit testing.
+   *
+   * @returns {SQSClient} The SQS client instance.
+   */
+  get getSQSClient() {
+    return this.#sqsClient
+  }
 
   /**
    * Sends a message to the specified queue.

--- a/test/queue-adapter.test.js
+++ b/test/queue-adapter.test.js
@@ -112,4 +112,18 @@ describe('QueueAdapter', () => {
 
     Sinon.assert.calledOnceWithExactly(consoleErrorStub, 'Failed to send message', error)
   })
+
+  it('creates a new QueueAdapter with a custom endpoint', async () => {
+    const endpoint = 'http://localhost:4575' // LocalStack SNS endpoint for local testing
+    const customQueueAdapter = new QueueAdapter({ endpoint })
+
+    expect(customQueueAdapter).to.exist()
+    expect(customQueueAdapter).to.be.an.instanceof(QueueAdapter)
+
+    const client = customQueueAdapter.getSQSClient
+    const actualEndpoint = await client.config.endpoint()
+
+    expect(actualEndpoint.hostname).to.equal('localhost')
+    expect(actualEndpoint.port).to.equal(4575)
+  })
 })


### PR DESCRIPTION
This PR introduces a new feature that allows developers to specify a custom endpoint for the SQS client. This is particularly useful for local development and testing, where developers might want to use a local mock SQS service instead of the real AWS service.